### PR TITLE
Feature/drupal password

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,8 @@
 		{ "name": "Tim Gunter", "email": "tim@vanillaforums.com", "role": "developer" }
 	],
 	"require": {
-		"php": ">=5.4.0"
+		"php": ">=5.4.0",
+		"mdespeuilles/drupalpasswordencoderbundle": "*"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "~6.0"

--- a/src/DrupalPassword.php
+++ b/src/DrupalPassword.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * @author Olivier Lamy-Canuel <olamy-canuel@higherlogic.com>
+ * @copyright 2006 Drupal (Original source code)
+ * @copyright 2021 Higher Logic (Source code changes)
+ * @license http://opensource.org/licenses/gpl-license.php GNU Public License
+ *
+ */
+
+namespace Garden\Password;
+
+use Mdespeuilles\DrupalPasswordEncoderBundle\Services\DrupalPasswordEncoder;
+use Mdespeuilles\DrupalPasswordEncoderBundle\Services\Password\PhpassHashedPassword;
+
+/**
+ * Implements Drupal's password hashing algorithm. Valid for Drupal 7 and 8.
+ */
+class DrupalPassword implements PasswordInterface {
+
+    /**
+     * Check for a correct password.
+     *
+     * @param string $password The password in plain text.
+     * @param string $hash The stored password hash.
+     * @return bool Returns true if the password is correct, false if not.
+     */
+    public function verify($password, $hash) {
+        return DrupalPasswordEncoder::isPasswordValid($hash, $password, NULL);
+    }
+
+    /**
+     * Hashes a plaintext password.
+     *
+     * @param string $password The password to hash.
+     * @return string Returns the hashed password.
+     */
+    public function hash($password) {
+        return DrupalPasswordEncoder::encodePassword($password);
+    }
+
+    /**
+     * Checks if a given password hash needs to be re-hashed to a stronger algorithm.
+     *
+     * @param string $hash The hash to check.
+     * @return bool Returns `true`
+     */
+    public function needsRehash($hash) {
+        return PhpassHashedPassword::needsRehash($hash);
+    }
+}

--- a/tests/PasswordTest.php
+++ b/tests/PasswordTest.php
@@ -8,6 +8,7 @@
 namespace Garden\Tests;
 
 use Garden\Password\DjangoPassword;
+use Garden\Password\DrupalPassword;
 use Garden\Password\PasswordInterface;
 use Garden\Password\PhpassPassword;
 use Garden\Password\PhpPassword;
@@ -307,5 +308,14 @@ class PasswordTest extends TestCase {
         $result['Xenforo sha256'] = [new XenforoPassword('sha256')];
 
         return $result;
+    }
+
+    /**
+     * Test some edge cases of {@link DrupalPassword}.
+     */
+    public function testDrupalPassword() {
+        $pw = new DrupalPassword();
+        $this->assertTrue($pw->verify('w_VkxdHRPjRJY7dgfGdb3q98', '$S$DKAFXs1HceSMqIllAL7GDC1/yl78icSWbCGtNCQaFpm3gpjSXYMT'));
+        $this->assertTrue($pw->verify('CSN@Vanilla', '$S$DScF4C6qIjwrGMmnl7Xqbjx9yPCQ3Jq5.1NnpP6ZlYWZPX9HebZo'));
     }
 }


### PR DESCRIPTION
# Issue
* Missing password support for Drupal 7.

# Solution 
* Use an existing library (approved by InfoSec) to do the implementation.

# QA
* An automated test based on Drupal data was added. 

# How to test
1) Create a Symlink of `DrupalPassword.php` into `vanilla/vendor/vanilla/garden-password/src`.
2) From the database, change a User so that the HashMethod is set to `Drupal` and the password is set as follows: `$S$DScF4C6qIjwrGMmnl7Xqbjx9yPCQ3Jq5.1NnpP6ZlYWZPX9HebZo`. 
3) Try to connect as the User with the following password: `CSN@Vanilla`
4) Notice that you are properly connected as the User.