### PR TITLE
VNLA-7529: upgrade php8.1

### DIFF
--- a/src/PhpassPassword.php
+++ b/src/PhpassPassword.php
@@ -142,7 +142,7 @@ class PhpassPassword implements PasswordInterface
         // entropy.
 
         $output = '$2a$';
-        $output .= chr(ord("0") + (int) $this->iteration_count_log2 / 10);
+        $output .= chr(ord("0") + intval($this->iteration_count_log2 / 10));
         $output .= chr(ord("0") + ($this->iteration_count_log2 % 10));
         $output .= '$';
 

--- a/src/PhpassPassword.php
+++ b/src/PhpassPassword.php
@@ -143,7 +143,7 @@ class PhpassPassword implements PasswordInterface
 
         $output = '$2a$';
         $output .= chr(ord("0") + (int) $this->iteration_count_log2 / 10);
-        $output .= chr(ord("0") + ((int) $this->iteration_count_log2 % 10));
+        $output .= chr(ord("0") + ($this->iteration_count_log2 % 10));
         $output .= '$';
 
         $i = 0;


### PR DESCRIPTION
# Changes
* Replace casting as int with `intval()`. The former is causing precision errors in PHP 8.1+.